### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,4 +1,6 @@
 name: Unit Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/AtteBox/text-edit-practice/security/code-scanning/2](https://github.com/AtteBox/text-edit-practice/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
