### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,6 @@
 name: End-to-end Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/AtteBox/text-edit-practice/security/code-scanning/1](https://github.com/AtteBox/text-edit-practice/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to check out the repository and does not perform any write operations on the repository contents.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
