### PR TITLE
Fix Mac detection hydration mismatch in LevelScreen

### DIFF
--- a/src/app/hooks/useIsMac.ts
+++ b/src/app/hooks/useIsMac.ts
@@ -1,0 +1,8 @@
+import { useSyncExternalStore } from "react";
+import { isMac } from "../utils";
+
+const subscribe = () => () => {};
+
+export function useIsMac() {
+  return useSyncExternalStore(subscribe, isMac, () => false);
+}

--- a/src/app/screens/LevelScreen.tsx
+++ b/src/app/screens/LevelScreen.tsx
@@ -1,10 +1,10 @@
-import { isMac } from "../utils";
 import { GameResultsBar } from "../components/GameResultsBar";
 import LevelResultsBar from "../components/LevelResultsBar";
 import { useLevelEngine } from "../engines/level";
 import { IGameEngineResult } from "../engines/game";
 import { IGameHistory } from "../engines/gameHistory";
 import { useCallback } from "react";
+import { useIsMac } from "../hooks/useIsMac";
 
 function LevelScreen({
   game,
@@ -119,8 +119,10 @@ function KeyCombinationTag({
     Delete: "remove letter on right",
   };
 
+  const mac = useIsMac();
+
   let actualKeyCombination = keyCombination;
-  if (isMac()) {
+  if (mac) {
     actualKeyCombination = actualKeyCombination.map((key) =>
       key === "ctrl" ? "option" : key,
     );


### PR DESCRIPTION
isMac() was called directly during render, causing SSR to render
Windows keys (Ctrl) which then flipped to Mac keys (Option) after
hydration. Use useSyncExternalStore to safely read navigator.platform
with a server fallback of false.

https://claude.ai/code/session_019SQyk6yZtHEkAvDGaZvESD