### PR TITLE
Fix cross-origin blocked request for Next.js dev HMR

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  allowedDevOrigins: ["http://127.0.0.1", "http://localhost"],
+};
 
 export default nextConfig;


### PR DESCRIPTION
Add allowedDevOrigins to next.config.mjs to permit webpack-hmr
requests from both 127.0.0.1 and localhost during development.

https://claude.ai/code/session_01Hx2Y4Uh3isR7RGkgSQBWQq