### PR TITLE
Fix Next.js HMR CORS blocked cross-origin request

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  allowedDevOrigins: ["*.localhost", "*.127.0.0.1"],
+  allowedDevOrigins: ["http://127.0.0.1:3000"],
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  allowedDevOrigins: ["http://127.0.0.1:3000"],
+  allowedDevOrigins: ["http://127.0.0.1:3000", "http://localhost:3000"],
 };
 
 export default nextConfig;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  allowedDevOrigins: ["http://127.0.0.1", "http://localhost"],
+  allowedDevOrigins: ["*.localhost", "*.127.0.0.1"],
 };
 
 export default nextConfig;


### PR DESCRIPTION
Use wildcard patterns in allowedDevOrigins to match all ports
for localhost and 127.0.0.1, fixing the webpack-hmr CORS warning.

https://claude.ai/code/session_01JowVfYSLRHFVjaWWdpDuWF