### PR TITLE
Add selection and clipboard support to virtual textarea

### DIFF
--- a/e2e-tests/game.spec.ts
+++ b/e2e-tests/game.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { keysByLevel, level1FailKeys, level5FailKeys } from "./keySequences";
+import { keysByLevel, level1FailKeys, level6FailKeys } from "./keySequences";
 
 test("when page is loaded, initially show start view", async ({ page }) => {
 
@@ -92,7 +92,7 @@ test("when played through first level with too many mistakes, show level failed 
   await expect(page.getByText("Welcome to Typo Terminator!")).toBeVisible();
 });
 
-test("when played through last level with too many mistakes, show level failed message", async ({
+test("when a germ level is failed with too many mistakes, show level failed message", async ({
   page,
   browserName,
 }) => {
@@ -100,14 +100,18 @@ test("when played through last level with too many mistakes, show level failed m
   await page.goto("/");
   await page.fill("input", "Test User");
   await page.getByRole("button", { name: "Start Game" }).click();
-  for (let i = 0; i < keysByLevel.length; i++) {
-    const isLastLevel = i === keysByLevel.length - 1;
-    const levelKeys = isLastLevel ? level5FailKeys : keysByLevel[i];
+  // The last level is a target level that can only fail by timeout, so fail
+  // level 6 instead: clearing every word removes the germs (the goal) but
+  // also every animal, dropping the score to zero.
+  const failLevelIndex = 5; // level 6
+  for (let i = 0; i <= failLevelIndex; i++) {
+    const isFailLevel = i === failLevelIndex;
+    const levelKeys = isFailLevel ? level6FailKeys : keysByLevel[i];
     await expect(page.getByText(`Level ${i + 1}`)).toBeVisible();
     for (const key of levelKeys) {
       await pressGameKey(page, key);
     }
-    if (isLastLevel) {
+    if (isFailLevel) {
       await expect(page.getByText(`Level ${i + 1} Failed`)).toBeVisible();
       await expect(
         page.getByText(`Level ${i + 1} Completed`),
@@ -117,6 +121,40 @@ test("when played through last level with too many mistakes, show level failed m
       await page.getByRole("button", { name: "Next Level" }).click();
     }
   }
+});
+
+test("when a target level runs out of time, it fails", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(browserName === "webkit", "TODO: Still working on it");
+  // Shrink the level 7/8 time limit so the timeout fires quickly. Only levels
+  // that already have a maxTimeSeconds are affected, so levels 1-6 are normal.
+  await page.addInitScript(() => {
+    (
+      globalThis as unknown as {
+        __typoTerminatorTestOverrides?: { maxTimeSecondsOverride?: number };
+      }
+    ).__typoTerminatorTestOverrides = { maxTimeSecondsOverride: 3 };
+  });
+  await page.goto("/");
+  await page.fill("input", "Test User");
+  await page.getByRole("button", { name: "Start Game" }).click();
+  // Play levels 1-6 normally (they have no time limit)
+  for (let i = 0; i < 6; i++) {
+    await expect(page.getByText(`Level ${i + 1}`)).toBeVisible();
+    for (const key of keysByLevel[i]) {
+      await pressGameKey(page, key);
+    }
+    await expect(page.getByText(`Level ${i + 1} Completed`)).toBeVisible();
+    await page.getByRole("button", { name: "Next Level" }).click();
+  }
+  // Level 7 has a time limit; idle and let it time out
+  await expect(page.getByText("Level 7", { exact: false })).toBeVisible();
+  await expect(page.getByText("Time limit:", { exact: false })).toBeVisible();
+  await expect(page.getByText("Level 7 Failed")).toBeVisible({
+    timeout: 15000,
+  });
 });
 
 test("when played through the game, show finished game view and calculate total points correctly. Also persist history to db", async ({
@@ -133,6 +171,15 @@ test("when played through the game, show finished game view and calculate total 
     await expect(page.getByText(`Level ${i + 1}`)).toBeVisible();
     // points should be zero at the beginning of each level
     await expect(extractPoints(page)).resolves.toBe(0);
+    // Level 7 is the first target level: it shows the target panel and the
+    // cut/paste key tags.
+    if (i === 6) {
+      await expect(
+        page.getByText("make the text look like this", { exact: false }),
+      ).toBeVisible();
+      await expect(page.getByText("cut selection")).toBeVisible();
+      await expect(page.getByText("paste")).toBeVisible();
+    }
     for (const key of keysByLevel[i]) {
       await pressGameKey(page, key);
     }
@@ -140,8 +187,8 @@ test("when played through the game, show finished game view and calculate total 
       await expect(page.getByText(`Congratulations!`)).toBeVisible();
       await expect(
         page.getByText("Time:", { exact: false }),
-        "should have finished and recorded 5 levels",
-      ).toHaveCount(5);
+        "should have finished and recorded all levels",
+      ).toHaveCount(keysByLevel.length);
     } else {
       await expect(page.getByText(`Level ${i + 1} Completed`)).toBeVisible();
     }
@@ -221,7 +268,17 @@ test("when playing a level, user can pause and resume the game", async ({
  */
 async function pressGameKey(page: Page, key: string) {
   const mac = await isMac(page);
-  await page.keyboard.press(mac ? key.replace("Control", "Alt") : key);
+  if (!mac) {
+    await page.keyboard.press(key);
+    return;
+  }
+  // On Mac, clipboard combos use Cmd (Meta) while word/navigation combos use
+  // Option (Alt). Shift is unchanged.
+  const isClipboard =
+    key === "Control+x" || key === "Control+c" || key === "Control+v";
+  await page.keyboard.press(
+    key.replace("Control", isClipboard ? "Meta" : "Alt"),
+  );
 }
 
 /**

--- a/e2e-tests/game.spec.ts
+++ b/e2e-tests/game.spec.ts
@@ -128,6 +128,9 @@ test("when a target level runs out of time, it fails", async ({
   browserName,
 }) => {
   test.skip(browserName === "webkit", "TODO: Still working on it");
+  // Playing levels 1-6 and then idling on level 7 takes a while, so give the
+  // test plenty of headroom beyond the default 30s budget.
+  test.setTimeout(120_000);
   // Shrink the level 7/8 time limit so the timeout fires quickly. Only levels
   // that already have a maxTimeSeconds are affected, so levels 1-6 are normal.
   await page.addInitScript(() => {
@@ -162,6 +165,8 @@ test("when played through the game, show finished game view and calculate total 
   browserName,
 }) => {
   test.skip(browserName === "webkit", "TODO: Still working on it");
+  // The playthrough now spans 8 levels, so allow more than the default budget.
+  test.setTimeout(120_000);
   await page.goto("/");
   await page.fill("input", "Test User");
   await page.getByRole("button", { name: "Start Game" }).click();
@@ -172,13 +177,14 @@ test("when played through the game, show finished game view and calculate total 
     // points should be zero at the beginning of each level
     await expect(extractPoints(page)).resolves.toBe(0);
     // Level 7 is the first target level: it shows the target panel and the
-    // cut/paste key tags.
+    // cut/paste key tags. Match the tag explanation text (in parentheses) so
+    // we don't collide with the title/description, which also contain "paste".
     if (i === 6) {
       await expect(
         page.getByText("make the text look like this", { exact: false }),
       ).toBeVisible();
-      await expect(page.getByText("cut selection")).toBeVisible();
-      await expect(page.getByText("paste")).toBeVisible();
+      await expect(page.getByText("(cut selection)")).toBeVisible();
+      await expect(page.getByText("(paste)")).toBeVisible();
     }
     for (const key of keysByLevel[i]) {
       await pressGameKey(page, key);

--- a/e2e-tests/helpers.ts
+++ b/e2e-tests/helpers.ts
@@ -21,12 +21,9 @@ export function createRandomGameHistory(): IGameHistory {
 }
 
 function mapToVirtualTextareaKeyCombination(keyCombination: string): string[] {
-  const keys = keyCombination.split("+");
-  if (keys.length === 1) {
-    return [keys[0]];
-  }
-  if (keys.length === 2) {
-    return [keys[0].replace("Control", "ctrl"), keys[1]];
-  }
-  return [];
+  return keyCombination
+    .split("+")
+    .map((key) =>
+      key === "Control" ? "ctrl" : key === "Shift" ? "shift" : key,
+    );
 }

--- a/e2e-tests/keySequences.ts
+++ b/e2e-tests/keySequences.ts
@@ -741,13 +741,21 @@ export const keysByLevel = [
     "Control+Shift+ArrowRight",
     "Backspace",
   ],
-  // Level 7: cut " 🐭" and paste it after "🐶"
+  // Level 7: move whole words with Ctrl+Shift selection to reach the target
   [
-    "Shift+ArrowLeft",
-    "Shift+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowLeft",
     "Control+x",
     "Control+ArrowLeft",
-    "ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+v",
+    "Control+ArrowRight",
+    "Control+ArrowRight",
+    "Control+ArrowRight",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowLeft",
+    "Control+x",
+    "Control+ArrowLeft",
     "Control+v",
   ],
   // Level 8: copy " 🐞 🦋" and paste it at the end

--- a/e2e-tests/keySequences.ts
+++ b/e2e-tests/keySequences.ts
@@ -728,6 +728,53 @@ export const keysByLevel = [
     "ArrowLeft",
     "Control+Backspace",
   ],
+  // Level 6: select germ words with shift and delete them
+  [
+    "Control+Shift+ArrowLeft",
+    "Backspace",
+    "Control+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowRight",
+    "Backspace",
+    "Control+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowRight",
+    "Backspace",
+  ],
+  // Level 7: cut " 🐭" and paste it after "🐶"
+  [
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Control+x",
+    "Control+ArrowLeft",
+    "ArrowLeft",
+    "Control+v",
+  ],
+  // Level 8: copy " 🐞 🦋" and paste it at the end
+  [
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Control+c",
+    "ArrowRight",
+    "Control+v",
+  ],
+];
+
+// Fails level 6 by deleting the animal words instead of the germs, leaving
+// zero animals (and thus zero points). Used to exercise a non-target failure.
+export const level6FailKeys = [
+  "Control+Shift+ArrowLeft",
+  "Backspace",
+  "Control+Shift+ArrowLeft",
+  "Backspace",
+  "Control+Shift+ArrowLeft",
+  "Backspace",
+  "Control+Shift+ArrowLeft",
+  "Backspace",
+  "Control+Shift+ArrowLeft",
+  "Backspace",
 ];
 
 export const level1FailKeys = [

--- a/src/app/components/LevelResultsBar.tsx
+++ b/src/app/components/LevelResultsBar.tsx
@@ -5,22 +5,36 @@ function LevelResultsBar({ levelResults }: { levelResults: ILevelResult }) {
   const level = levelResults.currentLevel;
   return (
     <div className="flex gap-4">
+      {levelResults.levelTotalGerms > 0 && (
+        <>
+          <p
+            className="text-sm"
+            style={{
+              color: getDangerColor(
+                (levelResults.germs ?? 0) / levelResults.levelTotalGerms,
+              ),
+            }}
+          >
+            Germs: {levelResults.germs}/{levelResults.levelTotalGerms}
+          </p>
+          <p className="text-sm">+</p>
+        </>
+      )}
       <p
         className="text-sm"
         style={{
           color: getDangerColor(
-            (levelResults.germs ?? 0) / levelResults.levelTotalGerms,
-          ),
-        }}
-      >
-        Germs: {levelResults.germs}/{levelResults.levelTotalGerms}
-      </p>
-      <p className="text-sm">+</p>
-      <p
-        className="text-sm"
-        style={{
-          color: getDangerColor(
-            1 - (levelResults.animals ?? 0) / levelResults.levelTotalAnimals,
+            levelResults.levelTotalAnimals === 0
+              ? 1
+              : Math.max(
+                  0,
+                  Math.min(
+                    1,
+                    1 -
+                      (levelResults.animals ?? 0) /
+                        levelResults.levelTotalAnimals,
+                  ),
+                ),
           ),
         }}
       >

--- a/src/app/engines/game.ts
+++ b/src/app/engines/game.ts
@@ -99,6 +99,7 @@ export function useGameEngine({
           level: state.currentLevel,
           germs: state.germs,
           animals: state.animals,
+          goalReached: state.goalReached,
           startTime: state.startTime,
           elapsedTime: state.elapsedTime,
           levelFinished: true,

--- a/src/app/engines/game.ts
+++ b/src/app/engines/game.ts
@@ -7,6 +7,8 @@ import {
   IGameState,
   ILevel,
   ILevelResult,
+  isLevelGoalReached,
+  isLevelTimedOut,
 } from "../gameUtilities";
 import { usernameSchema } from "../../schema";
 
@@ -53,7 +55,8 @@ export function useGameEngine({
 
   const isLastLevel = gameState.currentLevel === levels.length;
   const levelFailed =
-    !!gameState.levelFinished && calcPoints(gameState, level) <= 0;
+    !!gameState.levelFinished &&
+    (calcPoints(gameState, level) <= 0 || !!gameState.timedOut);
 
   const totalPauseDuration = useMemo(
     () =>
@@ -81,6 +84,8 @@ export function useGameEngine({
     setGameState((state) => ({
       ...state,
       levelFinished: false,
+      goalReached: undefined,
+      timedOut: undefined,
       germs: undefined,
       animals: undefined,
       startTime: Date.now(),
@@ -171,9 +176,10 @@ export function useGameEngine({
     ({ textContent }: { textContent: string }) => {
       const germs = getGermCount(textContent);
       const animals = getAnimalCount(textContent);
-      updateGameState({ germs, animals });
+      const goalReached = isLevelGoalReached(level, textContent);
+      updateGameState({ germs, animals, goalReached });
     },
-    [updateGameState],
+    [updateGameState, level],
   );
 
   const currentLevelPoints = useMemo(
@@ -219,10 +225,27 @@ export function useGameEngine({
   const isGameFinished = isLastLevel && gameState.levelFinished;
 
   useEffect(() => {
-    if (gameState.germs === 0) {
+    if (gameState.goalReached) {
       updateGameState({ levelFinished: true });
     }
-  }, [gameState.germs, updateGameState]);
+  }, [gameState.goalReached, updateGameState]);
+
+  // auto-fail levels that run past their maximum time
+  useEffect(() => {
+    if (
+      gameState.gameHasStarted &&
+      !gameState.levelFinished &&
+      isLevelTimedOut(level, gameState.elapsedTime)
+    ) {
+      updateGameState({ levelFinished: true, timedOut: true });
+    }
+  }, [
+    gameState.elapsedTime,
+    gameState.gameHasStarted,
+    gameState.levelFinished,
+    level,
+    updateGameState,
+  ]);
 
   useEffect(() => {
     if (

--- a/src/app/engines/level.ts
+++ b/src/app/engines/level.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { ctrlEquivalentPressed } from "../utils";
+import { clipboardModifierPressed, ctrlEquivalentPressed, isMac } from "../utils";
 import { calcTextarea, ITextareaState } from "../virtualTextarea";
 import { IGameEngineResult } from "./game";
 import {
@@ -7,6 +7,54 @@ import {
   ILevel,
   startContentToText,
 } from "../gameUtilities";
+
+/**
+ * Matches a physical keyboard event against a platform-neutral key
+ * combination such as ["ctrl", "shift", "ArrowLeft"] or ["ctrl", "x"].
+ *
+ * Word/navigation ctrl combos map to Ctrl on Windows/Linux and Option on Mac.
+ * Clipboard combos (ctrl + x/c/v) map to Ctrl on Windows/Linux and Cmd on Mac;
+ * their letter is matched via e.code since Option/Cmd can alter e.key.
+ */
+function matchesKeyCombination(
+  e: globalThis.KeyboardEvent,
+  keyCombination: string[],
+): boolean {
+  const baseKey = keyCombination[keyCombination.length - 1];
+  const modifiers = keyCombination.slice(0, -1);
+  const wantCtrl = modifiers.includes("ctrl");
+  const wantShift = modifiers.includes("shift");
+  const isClipboard =
+    wantCtrl && (baseKey === "x" || baseKey === "c" || baseKey === "v");
+
+  if (e.shiftKey !== wantShift) {
+    return false;
+  }
+
+  const ctrlModifierPressed = isClipboard
+    ? clipboardModifierPressed(e)
+    : ctrlEquivalentPressed(e);
+  if (ctrlModifierPressed !== wantCtrl) {
+    return false;
+  }
+
+  // Reject stray command modifiers this combo does not use, so that e.g.
+  // Cmd+ArrowLeft on Mac doesn't trigger a Ctrl word move.
+  if (isMac()) {
+    if (e.ctrlKey) {
+      return false;
+    }
+    if (isClipboard ? e.altKey : e.metaKey) {
+      return false;
+    }
+  } else if (e.metaKey || e.altKey) {
+    return false;
+  }
+
+  return isClipboard
+    ? e.code === `Key${baseKey.toUpperCase()}`
+    : e.key === baseKey;
+}
 
 function initialTextareaState(
   level: Pick<ILevel, "startContent" | "cursorStartPos">,
@@ -65,31 +113,12 @@ export function useLevelEngine({
 
   const handleKeyDown = useCallback(
     (e: globalThis.KeyboardEvent) => {
-      const pressedModifierCount = [
-        e.ctrlKey,
-        e.metaKey,
-        e.altKey,
-        e.shiftKey,
-      ].filter((pressed) => pressed).length;
       for (const keyCombination of level.allowedKeyCombinations) {
-        if (
-          pressedModifierCount === 0 &&
-          keyCombination.length === 1 &&
-          e.key === keyCombination[0]
-        ) {
+        if (matchesKeyCombination(e, keyCombination)) {
+          // prevent the browser's native clipboard/selection actions
+          e.preventDefault();
           handleAllowedKeyCombination(keyCombination);
           return;
-        }
-        if (pressedModifierCount === 1 && keyCombination.length === 2) {
-          const [ctrlKey, keyName] = keyCombination;
-          if (
-            ctrlKey === "ctrl" &&
-            ctrlEquivalentPressed(e) &&
-            e.key === keyName
-          ) {
-            handleAllowedKeyCombination(keyCombination);
-            return;
-          }
         }
       }
       // prevent disallowed key combinations

--- a/src/app/engines/level.ts
+++ b/src/app/engines/level.ts
@@ -1,11 +1,26 @@
 import { useCallback, useEffect, useState } from "react";
 import { ctrlEquivalentPressed } from "../utils";
-import { calcTextarea } from "../virtualTextarea";
+import { calcTextarea, ITextareaState } from "../virtualTextarea";
 import { IGameEngineResult } from "./game";
 import {
   getActualInitialCursorPos,
+  ILevel,
   startContentToText,
 } from "../gameUtilities";
+
+function initialTextareaState(
+  level: Pick<ILevel, "startContent" | "cursorStartPos">,
+): ITextareaState {
+  return {
+    text: startContentToText(level.startContent),
+    cursorPos: getActualInitialCursorPos(
+      level.cursorStartPos,
+      level.startContent,
+    ),
+    selectionAnchor: null,
+    clipboard: "",
+  };
+}
 
 export function useLevelEngine({
   game,
@@ -15,25 +30,21 @@ export function useLevelEngine({
   onKeyStroke: (keyCombination: string[]) => void;
 }) {
   const level = game.currentLevel;
-  const [gameMap, setGameMap] = useState<string>(
-    startContentToText(level.startContent),
+  const [textareaState, setTextareaState] = useState<ITextareaState>(() =>
+    initialTextareaState(level),
   );
   const [currentKeyCombination, setCurrentKeyCombination] = useState<
     string[] | null
   >(null);
-  const [cursorPos, setCursorPos] = useState<number>(0);
 
-  //when level changes, reset the game map
+  //when level changes, reset the textarea state
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setGameMap(startContentToText(level.startContent));
-  }, [level.startContent, setGameMap]);
-
-  // when level changes, reset the cursor position
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setCursorPos(
-      getActualInitialCursorPos(level.cursorStartPos, level.startContent),
+    setTextareaState(
+      initialTextareaState({
+        startContent: level.startContent,
+        cursorStartPos: level.cursorStartPos,
+      }),
     );
   }, [level.cursorStartPos, level.startContent]);
 
@@ -43,18 +54,13 @@ export function useLevelEngine({
     (keyCombination: string[]) => {
       setCurrentKeyCombination(keyCombination);
 
-      const { cursorPos: newCursorPos, text: newGameMap } = calcTextarea(
-        cursorPos,
-        gameMap,
-        keyCombination,
-      );
-      setGameMap(newGameMap);
-      setCursorPos(newCursorPos);
+      const newTextareaState = calcTextarea(textareaState, keyCombination);
+      setTextareaState(newTextareaState);
 
-      updateLevelStats({ textContent: newGameMap });
+      updateLevelStats({ textContent: newTextareaState.text });
       onKeyStroke(keyCombination);
     },
-    [gameMap, cursorPos, updateLevelStats, onKeyStroke],
+    [textareaState, updateLevelStats, onKeyStroke],
   );
 
   const handleKeyDown = useCallback(
@@ -145,5 +151,19 @@ export function useLevelEngine({
     }
   }, [game.gameHasStarted, game.levelFinished, pauseGame]);
 
-  return { gameMap, currentKeyCombination, cursorPos };
+  const selection =
+    textareaState.selectionAnchor === null ||
+    textareaState.selectionAnchor === textareaState.cursorPos
+      ? null
+      : {
+          start: Math.min(textareaState.selectionAnchor, textareaState.cursorPos),
+          end: Math.max(textareaState.selectionAnchor, textareaState.cursorPos),
+        };
+
+  return {
+    gameMap: textareaState.text,
+    currentKeyCombination,
+    cursorPos: textareaState.cursorPos,
+    selection,
+  };
 }

--- a/src/app/gameUtilities/index.test.ts
+++ b/src/app/gameUtilities/index.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  calcPoints,
+  ILevel,
+  isLevelGoalReached,
+  isLevelTimedOut,
+} from ".";
+
+function aLevel(overrides: Partial<ILevel> = {}): ILevel {
+  return {
+    title: "Test",
+    description: "Test",
+    startContent: ["🐶 🦠 🐱"],
+    allowedKeyCombinations: [["ctrl", "Backspace"]],
+    cursorStartPos: "end",
+    postLevelMessage: "",
+    targetTimeSeconds: 60,
+    pointCoefficient: 100,
+    ...overrides,
+  };
+}
+
+function aLevelState(overrides: Record<string, unknown> = {}) {
+  return {
+    germs: 0,
+    animals: 0,
+    startTime: 0,
+    elapsedTime: 0,
+    levelFinished: false,
+    isPaused: false,
+    gamePauses: [],
+    ...overrides,
+  };
+}
+
+describe("calcPoints", () => {
+  it("does not produce NaN for levels without germs", () => {
+    const level = aLevel({ startContent: ["🐶 🐱"] });
+    const state = aLevelState({ germs: 0, animals: 2, elapsedTime: 0 });
+    const points = calcPoints(state, level);
+    expect(Number.isNaN(points)).toBe(false);
+    expect(points).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not award points for extra animals beyond the level total", () => {
+    // start has 2 animals, but state reports 4 (e.g. pasted duplicates)
+    const level = aLevel({ startContent: ["🐶 🐱"], targetTimeSeconds: 1000 });
+    const extraAnimals = aLevelState({ germs: 0, animals: 4, elapsedTime: 0 });
+    const exactAnimals = aLevelState({ germs: 0, animals: 2, elapsedTime: 0 });
+    // both should score the same: the surplus animals must not mint points
+    expect(calcPoints(extraAnimals, level)).toBe(
+      calcPoints(exactAnimals, level),
+    );
+  });
+
+  it("keeps legacy scoring stable", () => {
+    // 1 germ, 2 animals start; all germs removed, all animals kept, no time
+    const level = aLevel({
+      startContent: ["🐶 🦠 🐱"],
+      targetTimeSeconds: 60,
+      pointCoefficient: 100,
+    });
+    const state = aLevelState({ germs: 0, animals: 2, elapsedTime: 0 });
+    // germRatio = 1, animalRatio = 0, timeRatio = 0 => 100
+    expect(calcPoints(state, level)).toBe(100);
+  });
+});
+
+describe("isLevelGoalReached", () => {
+  it("requires zero germs for a germ-goal level", () => {
+    const level = aLevel({ startContent: ["🐶 🦠 🐱"] });
+    expect(isLevelGoalReached(level, "🐶 🦠 🐱")).toBe(false);
+    expect(isLevelGoalReached(level, "🐶  🐱")).toBe(true);
+  });
+
+  it("requires an exact text match for a target-content level", () => {
+    const level = aLevel({
+      startContent: ["🐶 🐱 🐭"],
+      targetContent: ["🐶 🐭 🐱"],
+    });
+    expect(isLevelGoalReached(level, "🐶 🐱 🐭")).toBe(false);
+    expect(isLevelGoalReached(level, "🐶 🐭 🐱")).toBe(true);
+  });
+});
+
+describe("isLevelTimedOut", () => {
+  afterEach(() => {
+    globalThis.__typoTerminatorTestOverrides = undefined;
+  });
+
+  it("never times out a level without maxTimeSeconds", () => {
+    const level = aLevel({ maxTimeSeconds: undefined });
+    expect(isLevelTimedOut(level, 1_000_000)).toBe(false);
+  });
+
+  it("times out only at or beyond the limit", () => {
+    const level = aLevel({ maxTimeSeconds: 90 });
+    expect(isLevelTimedOut(level, 89_000)).toBe(false);
+    expect(isLevelTimedOut(level, 90_000)).toBe(true);
+    expect(isLevelTimedOut(level, 120_000)).toBe(true);
+  });
+
+  it("honors the test override when a limit is set", () => {
+    globalThis.__typoTerminatorTestOverrides = { maxTimeSecondsOverride: 3 };
+    const level = aLevel({ maxTimeSeconds: 90 });
+    expect(isLevelTimedOut(level, 2_000)).toBe(false);
+    expect(isLevelTimedOut(level, 3_000)).toBe(true);
+  });
+
+  it("ignores the test override for levels without a limit", () => {
+    globalThis.__typoTerminatorTestOverrides = { maxTimeSecondsOverride: 3 };
+    const level = aLevel({ maxTimeSeconds: undefined });
+    expect(isLevelTimedOut(level, 1_000_000)).toBe(false);
+  });
+});

--- a/src/app/gameUtilities/index.test.ts
+++ b/src/app/gameUtilities/index.test.ts
@@ -53,6 +53,25 @@ describe("calcPoints", () => {
     );
   });
 
+  it("scores a target-content level by goal completion, not germs", () => {
+    const level = aLevel({
+      startContent: ["🐶 🐱 🐭"],
+      targetContent: ["🐶 🐭 🐱"],
+      targetTimeSeconds: 1000,
+      pointCoefficient: 150,
+    });
+    // before the goal is reached the level is worth nothing
+    const unfinished = aLevelState({ animals: 3, goalReached: false });
+    expect(calcPoints(unfinished, level)).toBe(0);
+    // once matched (all animals kept, negligible time) it earns full points
+    const finished = aLevelState({
+      animals: 3,
+      goalReached: true,
+      elapsedTime: 0,
+    });
+    expect(calcPoints(finished, level)).toBe(150);
+  });
+
   it("keeps legacy scoring stable", () => {
     // 1 germ, 2 animals start; all germs removed, all animals kept, no time
     const level = aLevel({

--- a/src/app/gameUtilities/index.ts
+++ b/src/app/gameUtilities/index.ts
@@ -114,8 +114,15 @@ export function calcPoints(gameState: ILevelState, level: ILevel) {
   const content = level.startContent.join("");
   const totalGerms = getGermCount(content);
   const totalAnimals = getAnimalCount(content);
-  const germRatio =
-    totalGerms === 0 ? 1 : 1 - (gameState.germs ?? 0) / totalGerms;
+  // Target-content levels are scored on whether the goal is reached (there are
+  // no germs to count); germ levels are scored on how many germs remain.
+  const goalRatio = level.targetContent
+    ? gameState.goalReached
+      ? 1
+      : 0
+    : totalGerms === 0
+      ? 1
+      : 1 - (gameState.germs ?? 0) / totalGerms;
   // clamped to 0 so that adding extra animals (e.g. by pasting) never adds points
   const animalRatio =
     totalAnimals === 0
@@ -128,7 +135,7 @@ export function calcPoints(gameState: ILevelState, level: ILevel) {
   );
   return Math.max(
     Math.floor(
-      (germRatio + 2 * animalRatio + timeRatio) * level.pointCoefficient,
+      (goalRatio + 2 * animalRatio + timeRatio) * level.pointCoefficient,
     ),
     0,
   );

--- a/src/app/gameUtilities/index.ts
+++ b/src/app/gameUtilities/index.ts
@@ -29,10 +29,21 @@ export type ILevel = {
   title: string;
   description: string;
   startContent: string[];
+  /**
+   * When set, the level is won by making the text match this content
+   * instead of removing all germs.
+   */
+  targetContent?: string[];
   allowedKeyCombinations: string[][];
   cursorStartPos: ICursorStartPos;
   postLevelMessage: string;
   targetTimeSeconds: number;
+  /**
+   * When set, the level automatically fails after this many seconds.
+   * Should be well above the time at which points drain to zero
+   * (e.g. 3x targetTimeSeconds).
+   */
+  maxTimeSeconds?: number;
   pointCoefficient: number;
 };
 
@@ -93,14 +104,23 @@ type ILevelState = {
   startTime: number;
   elapsedTime: number;
   levelFinished: boolean;
+  goalReached?: boolean;
+  timedOut?: boolean;
   isPaused: boolean;
   gamePauses: { startTime: number; endTime?: number }[];
 };
 
 export function calcPoints(gameState: ILevelState, level: ILevel) {
   const content = level.startContent.join("");
-  const germRatio = 1 - (gameState.germs ?? 0) / getGermCount(content);
-  const animalRatio = -(1 - (gameState.animals ?? 0) / getAnimalCount(content));
+  const totalGerms = getGermCount(content);
+  const totalAnimals = getAnimalCount(content);
+  const germRatio =
+    totalGerms === 0 ? 1 : 1 - (gameState.germs ?? 0) / totalGerms;
+  // clamped to 0 so that adding extra animals (e.g. by pasting) never adds points
+  const animalRatio =
+    totalAnimals === 0
+      ? 0
+      : Math.min(-(1 - (gameState.animals ?? 0) / totalAnimals), 0);
 
   const timeRatio = -Math.max(
     gameState.elapsedTime / 1000 / level.targetTimeSeconds,
@@ -174,4 +194,32 @@ export function getActualInitialCursorPos(
 
 export function startContentToText(startContent: string[]) {
   return startContent.join("\n");
+}
+
+export function isLevelGoalReached(
+  level: ILevel,
+  textContent: string,
+): boolean {
+  if (level.targetContent) {
+    return textContent === startContentToText(level.targetContent);
+  }
+  return getGermCount(textContent) === 0;
+}
+
+declare global {
+  var __typoTerminatorTestOverrides:
+    | { maxTimeSecondsOverride?: number }
+    | undefined;
+}
+
+export function isLevelTimedOut(level: ILevel, elapsedTime: number): boolean {
+  if (level.maxTimeSeconds === undefined) {
+    return false;
+  }
+  const maxTimeSeconds =
+    process.env.NODE_ENV !== "production"
+      ? (globalThis.__typoTerminatorTestOverrides?.maxTimeSecondsOverride ??
+        level.maxTimeSeconds)
+      : level.maxTimeSeconds;
+  return elapsedTime / 1000 >= maxTimeSeconds;
 }

--- a/src/app/gameValidation/index.spec.ts
+++ b/src/app/gameValidation/index.spec.ts
@@ -24,10 +24,10 @@ describe("Game Validation", () => {
     expect(result).toBe(false);
   });
   it("fail in level 7 when the target is not reached", () => {
-    // cut the word but never paste it back: text no longer matches target
+    // cut a word but never paste it back: text no longer matches target
     const keyRecording = mapToVirtualTextareaKeyRecording(keysByLevel, {
       level: 7,
-      keys: ["Shift+ArrowLeft", "Shift+ArrowLeft", "Control+x"],
+      keys: ["Control+ArrowLeft", "Control+Shift+ArrowLeft", "Control+x"],
     });
     const result = validateKeyRecording(keyRecording);
     expect(result).toBe(false);
@@ -819,13 +819,21 @@ const keysByLevel = [
     "Control+Shift+ArrowRight",
     "Backspace",
   ],
-  // Level 7: cut " 🐭" and paste it after "🐶"
+  // Level 7: move whole words with Ctrl+Shift selection to reach the target
   [
-    "Shift+ArrowLeft",
-    "Shift+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowLeft",
     "Control+x",
     "Control+ArrowLeft",
-    "ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+v",
+    "Control+ArrowRight",
+    "Control+ArrowRight",
+    "Control+ArrowRight",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowLeft",
+    "Control+x",
+    "Control+ArrowLeft",
     "Control+v",
   ],
   // Level 8: copy " 🐞 🦋" and paste it at the end

--- a/src/app/gameValidation/index.spec.ts
+++ b/src/app/gameValidation/index.spec.ts
@@ -23,6 +23,22 @@ describe("Game Validation", () => {
     const result = validateKeyRecording(keyRecording);
     expect(result).toBe(false);
   });
+  it("fail in level 7 when the target is not reached", () => {
+    // cut the word but never paste it back: text no longer matches target
+    const keyRecording = mapToVirtualTextareaKeyRecording(keysByLevel, {
+      level: 7,
+      keys: ["Shift+ArrowLeft", "Shift+ArrowLeft", "Control+x"],
+    });
+    const result = validateKeyRecording(keyRecording);
+    expect(result).toBe(false);
+  });
+  it("fail when level 8 is missing", () => {
+    const keyRecording = mapToVirtualTextareaKeyRecording(keysByLevel).filter(
+      (recording) => recording.level !== 8,
+    );
+    const result = validateKeyRecording(keyRecording);
+    expect(result).toBe(false);
+  });
   it("invalid timestamps", () => {
     const keyRecording = mapToVirtualTextareaKeyRecording(keysByLevel);
     keyRecording[2].pressedKeys[3].timestamp = 0;
@@ -53,14 +69,11 @@ function mapToVirtualTextareaKeyRecording(
 }
 
 function mapToVirtualTextareaKeyCombination(keyCombination: string): string[] {
-  const keys = keyCombination.split("+");
-  if (keys.length === 1) {
-    return [keys[0]];
-  }
-  if (keys.length === 2) {
-    return [keys[0].replace("Control", "ctrl"), keys[1]];
-  }
-  return [];
+  return keyCombination
+    .split("+")
+    .map((key) =>
+      key === "Control" ? "ctrl" : key === "Shift" ? "shift" : key,
+    );
 }
 
 const keysByLevel = [
@@ -792,6 +805,38 @@ const keysByLevel = [
     "Backspace",
     "ArrowLeft",
     "Control+Backspace",
+  ],
+  // Level 6: select germ words with shift and delete them
+  [
+    "Control+Shift+ArrowLeft",
+    "Backspace",
+    "Control+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowRight",
+    "Backspace",
+    "Control+ArrowLeft",
+    "Control+ArrowLeft",
+    "Control+Shift+ArrowRight",
+    "Backspace",
+  ],
+  // Level 7: cut " 🐭" and paste it after "🐶"
+  [
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Control+x",
+    "Control+ArrowLeft",
+    "ArrowLeft",
+    "Control+v",
+  ],
+  // Level 8: copy " 🐞 🦋" and paste it at the end
+  [
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Shift+ArrowLeft",
+    "Control+c",
+    "ArrowRight",
+    "Control+v",
   ],
 ];
 

--- a/src/app/gameValidation/index.ts
+++ b/src/app/gameValidation/index.ts
@@ -4,7 +4,7 @@ import {
   getGermCount,
   startContentToText,
 } from "../gameUtilities";
-import { calcTextarea } from "../virtualTextarea";
+import { calcTextarea, ITextareaState } from "../virtualTextarea";
 
 export type IKeyRecording = {
   level: number;
@@ -22,23 +22,25 @@ export function validateKeyRecording(keyRecording: IKeyRecording): boolean {
       return false;
     }
 
-    let text = startContentToText(level.startContent);
-    let cursorPos: number = getActualInitialCursorPos(
-      level.cursorStartPos,
-      level.startContent,
-    );
+    let textareaState: ITextareaState = {
+      text: startContentToText(level.startContent),
+      cursorPos: getActualInitialCursorPos(
+        level.cursorStartPos,
+        level.startContent,
+      ),
+      selectionAnchor: null,
+      clipboard: "",
+    };
     for (const pressedKey of levelRecording.pressedKeys) {
       if (pressedKey.timestamp < previousKeyDownTimestamp) {
         return false;
       }
       previousKeyDownTimestamp = pressedKey.timestamp;
 
-      const result = calcTextarea(cursorPos, text, pressedKey.keyCombination);
-      cursorPos = result.cursorPos;
-      text = result.text;
+      textareaState = calcTextarea(textareaState, pressedKey.keyCombination);
     }
 
-    if (getGermCount(text) > 0) {
+    if (getGermCount(textareaState.text) > 0) {
       return false;
     }
   }

--- a/src/app/gameValidation/index.ts
+++ b/src/app/gameValidation/index.ts
@@ -1,7 +1,7 @@
 import { levels } from "../levels";
 import {
   getActualInitialCursorPos,
-  getGermCount,
+  isLevelGoalReached,
   startContentToText,
 } from "../gameUtilities";
 import { calcTextarea, ITextareaState } from "../virtualTextarea";
@@ -22,6 +22,10 @@ export function validateKeyRecording(keyRecording: IKeyRecording): boolean {
       return false;
     }
 
+    const allowedKeyCombinations = new Set(
+      level.allowedKeyCombinations.map((combination) => combination.join("+")),
+    );
+
     let textareaState: ITextareaState = {
       text: startContentToText(level.startContent),
       cursorPos: getActualInitialCursorPos(
@@ -37,10 +41,14 @@ export function validateKeyRecording(keyRecording: IKeyRecording): boolean {
       }
       previousKeyDownTimestamp = pressedKey.timestamp;
 
+      if (!allowedKeyCombinations.has(pressedKey.keyCombination.join("+"))) {
+        return false;
+      }
+
       textareaState = calcTextarea(textareaState, pressedKey.keyCombination);
     }
 
-    if (getGermCount(textareaState.text) > 0) {
+    if (!isLevelGoalReached(level, textareaState.text)) {
       return false;
     }
   }

--- a/src/app/levels/index.ts
+++ b/src/app/levels/index.ts
@@ -115,7 +115,7 @@ export const levels: ILevel[] = [
     pointCoefficient: 200,
   },
   {
-    title: "Level 5: Mastering All Editing Techniques",
+    title: "Level 5: Combining All Deletion and Navigation Keys",
     description:
       "This is the ultimate test! Remove all the spiders from the text using all the key combinations you've learned so far. Use control key combinations for efficient word navigation and deletion, and use normal keys for precise character editing.",
     startContent: [
@@ -183,24 +183,22 @@ export const levels: ILevel[] = [
   {
     title: "Level 7: Cut and Paste",
     description:
-      "Rearrange the animals so the text matches the target below. Select a word with Shift, cut it with Ctrl+X, move the cursor where it belongs, and paste it with Ctrl+V. Tip: select the space along with the word so the spacing stays correct.",
-    startContent: ["🐶 🐱 🐭"],
-    targetContent: ["🐶 🐭 🐱"],
+      "Rearrange the animals so the text matches the target below. Hold Ctrl+Shift with the arrow keys to select a whole word at a time, cut it with Ctrl+X, jump between words with Ctrl and the arrow keys, and paste it where it belongs with Ctrl+V. Tip: selecting leftward grabs the word together with the space after it, so the spacing stays correct.",
+    startContent: ["🐶 🐱 🐭 🐹 🐰"],
+    targetContent: ["🐶 🐹 🐭 🐱 🐰"],
     allowedKeyCombinations: [
       ["ctrl", "x"],
       ["ctrl", "v"],
-      ["shift", "ArrowLeft"],
-      ["shift", "ArrowRight"],
+      ["ctrl", "shift", "ArrowLeft"],
+      ["ctrl", "shift", "ArrowRight"],
       ["ctrl", "ArrowLeft"],
       ["ctrl", "ArrowRight"],
-      ["ArrowLeft"],
-      ["ArrowRight"],
     ],
     cursorStartPos: "end",
     postLevelMessage:
-      "Great cut! Cutting moves text around. Copying, on the other hand, duplicates it — let's try that next.",
-    targetTimeSeconds: 30,
-    maxTimeSeconds: 90,
+      "Great cut! Cutting moves whole words around. Copying, on the other hand, duplicates them — let's try that next.",
+    targetTimeSeconds: 45,
+    maxTimeSeconds: 135,
     pointCoefficient: 150,
   },
   {

--- a/src/app/levels/index.ts
+++ b/src/app/levels/index.ts
@@ -154,8 +154,76 @@ export const levels: ILevel[] = [
     ],
     cursorStartPos: "middle",
     postLevelMessage:
-      "Outstanding! You've mastered all the editing techniques. You're now a text editing expert!",
+      "Outstanding! You've mastered deleting and navigating. Next up: selecting text with the Shift key.",
     targetTimeSeconds: 180,
     pointCoefficient: 250,
+  },
+  {
+    title: "Level 6: Selecting Text with Shift",
+    description:
+      "Remove the germs by selecting them. Hold Shift with the arrow keys to grow a selection a letter or a word at a time, then press Backspace to delete it. Use the other navigation keys to move between the animal words you want to keep.",
+    startContent: ["🐶🐶 🦠🦠🦠 🐱🐱", "🦠🦠 🐰🐰 🦠🦠🦠"],
+    allowedKeyCombinations: [
+      ["ctrl", "shift", "ArrowLeft"],
+      ["ctrl", "shift", "ArrowRight"],
+      ["shift", "ArrowLeft"],
+      ["shift", "ArrowRight"],
+      ["ctrl", "ArrowLeft"],
+      ["ctrl", "ArrowRight"],
+      ["Backspace"],
+      ["ArrowLeft"],
+      ["ArrowRight"],
+    ],
+    cursorStartPos: "end",
+    postLevelMessage:
+      "Nicely done! Selecting text is the foundation for cutting, copying and pasting — which is exactly what's coming next.",
+    targetTimeSeconds: 45,
+    pointCoefficient: 150,
+  },
+  {
+    title: "Level 7: Cut and Paste",
+    description:
+      "Rearrange the animals so the text matches the target below. Select a word with Shift, cut it with Ctrl+X, move the cursor where it belongs, and paste it with Ctrl+V. Tip: select the space along with the word so the spacing stays correct.",
+    startContent: ["🐶 🐱 🐭"],
+    targetContent: ["🐶 🐭 🐱"],
+    allowedKeyCombinations: [
+      ["ctrl", "x"],
+      ["ctrl", "v"],
+      ["shift", "ArrowLeft"],
+      ["shift", "ArrowRight"],
+      ["ctrl", "ArrowLeft"],
+      ["ctrl", "ArrowRight"],
+      ["ArrowLeft"],
+      ["ArrowRight"],
+    ],
+    cursorStartPos: "end",
+    postLevelMessage:
+      "Great cut! Cutting moves text around. Copying, on the other hand, duplicates it — let's try that next.",
+    targetTimeSeconds: 30,
+    maxTimeSeconds: 90,
+    pointCoefficient: 150,
+  },
+  {
+    title: "Level 8: Copy and Paste",
+    description:
+      "Duplicate the animals so the text matches the target below. Select the words you want to copy with Shift, copy them with Ctrl+C, move to the end and paste them with Ctrl+V.",
+    startContent: ["🐝 🐞 🦋"],
+    targetContent: ["🐝 🐞 🦋 🐞 🦋"],
+    allowedKeyCombinations: [
+      ["ctrl", "c"],
+      ["ctrl", "v"],
+      ["shift", "ArrowLeft"],
+      ["shift", "ArrowRight"],
+      ["ctrl", "ArrowLeft"],
+      ["ctrl", "ArrowRight"],
+      ["ArrowLeft"],
+      ["ArrowRight"],
+    ],
+    cursorStartPos: "end",
+    postLevelMessage:
+      "Outstanding! You've mastered selecting, cutting, copying and pasting. You're now a true text editing expert!",
+    targetTimeSeconds: 30,
+    maxTimeSeconds: 90,
+    pointCoefficient: 200,
   },
 ];

--- a/src/app/screens/LevelScreen.tsx
+++ b/src/app/screens/LevelScreen.tsx
@@ -4,6 +4,7 @@ import LevelResultsBar from "../components/LevelResultsBar";
 import { useLevelEngine } from "../engines/level";
 import { IGameEngineResult } from "../engines/game";
 import { IGameHistory } from "../engines/gameHistory";
+import { startContentToText } from "../gameUtilities";
 import { useCallback } from "react";
 
 function LevelScreen({
@@ -19,10 +20,11 @@ function LevelScreen({
       saveKeyStroke(game.currentLevelNumber, keyCombination),
     [game.currentLevelNumber, saveKeyStroke],
   );
-  const { gameMap, currentKeyCombination, cursorPos } = useLevelEngine({
-    game,
-    onKeyStroke: handleKeyStroke,
-  });
+  const { gameMap, currentKeyCombination, cursorPos, selection } =
+    useLevelEngine({
+      game,
+      onKeyStroke: handleKeyStroke,
+    });
   const level = game.currentLevel;
 
   return (
@@ -61,13 +63,28 @@ function LevelScreen({
           </button>
         </div>
         <p className="text-sm">{level.description}</p>
+        {level.maxTimeSeconds !== undefined && (
+          <p className="text-sm font-semibold text-red-300">
+            Time limit: {level.maxTimeSeconds}s (the level fails if you run out
+            of time)
+          </p>
+        )}
         <GameResultsBar game={game} alignRight={false} />
         <LevelResultsBar levelResults={game} />
         <GameMap
           gameMap={gameMap}
           cursorPos={cursorPos}
+          selection={selection}
           isPaused={game.isPaused}
         />
+        {level.targetContent && (
+          <div>
+            <span className="text-sm">
+              Target — make the text look like this:
+            </span>
+            <TargetMap text={startContentToText(level.targetContent)} />
+          </div>
+        )}
         <div>
           <span className="text-sm">Allowed key combinations:</span>
           <div className="flex flex-wrap grow-0 gap-1">
@@ -87,6 +104,8 @@ function LevelScreen({
 
 export default LevelScreen;
 
+type Explanation = string | { [key: string]: Explanation };
+
 function KeyCombinationTag({
   keyCombination,
   isPressed,
@@ -96,22 +115,35 @@ function KeyCombinationTag({
 }) {
   const keyText: Record<string, string> = {
     ctrl: "Control",
+    shift: "Shift",
     Backspace: "Backspace",
     ArrowLeft: "Left Arrow",
     ArrowRight: "Right Arrow",
     Delete: "Delete",
     option: "Option",
+    cmd: "Command",
     fn: "Fn",
+    x: "X",
+    c: "C",
+    v: "V",
   };
-  const keyCombinationExplanation: Record<
-    string,
-    string | Record<string, string>
-  > = {
+  const keyCombinationExplanation: Record<string, Explanation> = {
     ctrl: {
       Backspace: "remove left word",
       ArrowLeft: "move a word left",
       ArrowRight: "move a word right",
       Delete: "remove right word",
+      x: "cut selection",
+      c: "copy selection",
+      v: "paste",
+      shift: {
+        ArrowLeft: "select a word left",
+        ArrowRight: "select a word right",
+      },
+    },
+    shift: {
+      ArrowLeft: "select a letter left",
+      ArrowRight: "select a letter right",
     },
     Backspace: "remove letter on left",
     ArrowLeft: "move a letter left",
@@ -119,15 +151,26 @@ function KeyCombinationTag({
     Delete: "remove letter on right",
   };
 
+  const baseKey = keyCombination[keyCombination.length - 1];
+  const isClipboard =
+    keyCombination.includes("ctrl") &&
+    (baseKey === "x" || baseKey === "c" || baseKey === "v");
+
   let actualKeyCombination = keyCombination;
   if (isMac()) {
     actualKeyCombination = actualKeyCombination.map((key) =>
-      key === "ctrl" ? "option" : key,
+      key === "ctrl" ? (isClipboard ? "cmd" : "option") : key,
     );
     actualKeyCombination = actualKeyCombination.flatMap((key) =>
       key === "Delete" ? ["fn", "Backspace"] : key,
     );
   }
+
+  const explanation = keyCombination.reduce<Explanation>(
+    (acc, curr) => (typeof acc === "string" ? acc : acc[curr]),
+    keyCombinationExplanation,
+  );
+
   return (
     <div className="flex flex-col items-center m-2 text-xs">
       <span
@@ -137,16 +180,10 @@ function KeyCombinationTag({
           transition: isPressed ? "none" : "background-color 0.7s ease",
         }}
       >
-        {actualKeyCombination.map((k) => keyText[k]).join(" + ")}
+        {actualKeyCombination.map((k) => keyText[k] ?? k).join(" + ")}
       </span>
       <span className="text-xs">
-        (
-        {keyCombination.reduce(
-          //@ts-expect-error "TODO: typescript typing of this reduce"
-          (acc, curr) => acc[curr],
-          keyCombinationExplanation,
-        )}
-        )
+        ({typeof explanation === "string" ? explanation : ""})
       </span>
     </div>
   );
@@ -155,10 +192,12 @@ function KeyCombinationTag({
 function GameMap({
   gameMap,
   cursorPos,
+  selection,
   isPaused,
 }: {
   gameMap: string;
   cursorPos: number;
+  selection: { start: number; end: number } | null;
   isPaused: boolean;
 }) {
   const characters = Array.from(gameMap);
@@ -185,17 +224,31 @@ function GameMap({
       className="font-mono whitespace-pre-wrap break-words relative text-white rounded-md m-2 p-3"
     >
       <style>{blinkAnimation}</style>
-      {characters.map((char, index) => (
-        <span key={index} className="relative">
-          {index === cursorPos && (
-            <span
-              className="absolute inset-0 h-full w-0.5 bg-white"
-              style={{ animation: cursorAnimation }}
-            />
-          )}
-          {char}
-        </span>
-      ))}
+      {characters.map((char, index) => {
+        const isSelected =
+          selection !== null &&
+          index >= selection.start &&
+          index < selection.end;
+        return (
+          <span
+            key={index}
+            className="relative"
+            style={
+              isSelected
+                ? { backgroundColor: "rgba(255, 255, 255, 0.4)" }
+                : undefined
+            }
+          >
+            {index === cursorPos && (
+              <span
+                className="absolute inset-0 h-full w-0.5 bg-white"
+                style={{ animation: cursorAnimation }}
+              />
+            )}
+            {char}
+          </span>
+        );
+      })}
       {cursorPos === characters.length && (
         <span className="relative">
           <span
@@ -204,6 +257,22 @@ function GameMap({
           />
         </span>
       )}
+    </pre>
+  );
+}
+
+function TargetMap({ text }: { text: string }) {
+  return (
+    <pre
+      style={{
+        minWidth: "544px",
+        backgroundImage: "radial-gradient(#7CA05B, #5E8043)",
+        fontFamily: "var(--font-noto-emoji), monospace",
+        fontSize: "1.2rem",
+      }}
+      className="font-mono whitespace-pre-wrap break-words relative text-white rounded-md m-2 p-3"
+    >
+      {text}
     </pre>
   );
 }

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -9,6 +9,16 @@ export function ctrlEquivalentPressed(
 }
 
 /**
+ * The modifier used for clipboard combos (cut/copy/paste).
+ * On Mac this is Cmd, since Option+letter produces accented characters.
+ */
+export function clipboardModifierPressed(
+  event: KeyboardEvent | globalThis.KeyboardEvent,
+) {
+  return isMac() ? event.metaKey : event.ctrlKey;
+}
+
+/**
  * Call this function to assert that the code should never be reached.
  * For instance, in a switch statement, if all cases are handled, the default case should never be reached
  * @param value

--- a/src/app/virtualTextarea/index.test.ts
+++ b/src/app/virtualTextarea/index.test.ts
@@ -1,257 +1,437 @@
 import { describe, it, expect } from "vitest";
-import { calcTextarea } from ".";
+import { calcTextarea, ITextareaState } from ".";
+
+function aState(
+  cursorPos: number,
+  text: string,
+  overrides: Partial<ITextareaState> = {},
+): ITextareaState {
+  return { text, cursorPos, selectionAnchor: null, clipboard: "", ...overrides };
+}
 
 describe("calcTextarea", () => {
   describe("Single key operations", () => {
     it("moves cursor one position left when ArrowLeft is pressed", () => {
-      const result = calcTextarea(5, "Hello World", ["ArrowLeft"]);
-      expect(result).toEqual({ cursorPos: 4, text: "Hello World" });
+      const result = calcTextarea(aState(5, "Hello World"), ["ArrowLeft"]);
+      expect(result).toEqual(aState(4, "Hello World"));
     });
 
     it("does not move cursor left when at position 0", () => {
-      const result = calcTextarea(0, "Hello World", ["ArrowLeft"]);
-      expect(result).toEqual({ cursorPos: 0, text: "Hello World" });
+      const result = calcTextarea(aState(0, "Hello World"), ["ArrowLeft"]);
+      expect(result).toEqual(aState(0, "Hello World"));
     });
 
     it("moves cursor one position right when ArrowRight is pressed", () => {
-      const result = calcTextarea(5, "Hello World", ["ArrowRight"]);
-      expect(result).toEqual({ cursorPos: 6, text: "Hello World" });
+      const result = calcTextarea(aState(5, "Hello World"), ["ArrowRight"]);
+      expect(result).toEqual(aState(6, "Hello World"));
     });
 
     it("does not move cursor right when at end of text", () => {
       const text = "Hello World";
-      const result = calcTextarea(text.length, text, ["ArrowRight"]);
-      expect(result).toEqual({ cursorPos: text.length, text });
+      const result = calcTextarea(aState(text.length, text), ["ArrowRight"]);
+      expect(result).toEqual(aState(text.length, text));
     });
 
     it("deletes character before cursor when Backspace is pressed", () => {
-      const result = calcTextarea(6, "Hello World", ["Backspace"]);
-      expect(result).toEqual({ cursorPos: 5, text: "HelloWorld" });
+      const result = calcTextarea(aState(6, "Hello World"), ["Backspace"]);
+      expect(result).toEqual(aState(5, "HelloWorld"));
     });
 
     it("does not delete character when cursor is at position 0 and Backspace is pressed", () => {
-      const result = calcTextarea(0, "Hello World", ["Backspace"]);
-      expect(result).toEqual({ cursorPos: 0, text: "Hello World" });
+      const result = calcTextarea(aState(0, "Hello World"), ["Backspace"]);
+      expect(result).toEqual(aState(0, "Hello World"));
     });
 
     it("deletes character at cursor when Delete is pressed", () => {
-      const result = calcTextarea(5, "Hello World", ["Delete"]);
-      expect(result).toEqual({ cursorPos: 5, text: "HelloWorld" });
+      const result = calcTextarea(aState(5, "Hello World"), ["Delete"]);
+      expect(result).toEqual(aState(5, "HelloWorld"));
     });
 
     it("does not delete character when cursor is at end of text and Delete is pressed", () => {
       const text = "Hello World";
-      const result = calcTextarea(text.length, text, ["Delete"]);
-      expect(result).toEqual({ cursorPos: text.length, text });
+      const result = calcTextarea(aState(text.length, text), ["Delete"]);
+      expect(result).toEqual(aState(text.length, text));
     });
 
-    it("returns original cursor position and text when key is not handled", () => {
-      const result = calcTextarea(5, "Hello World", ["A"]);
-      expect(result).toEqual({ cursorPos: 5, text: "Hello World" });
+    it("returns original state when key is not handled", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["A"]);
+      expect(result).toEqual(aState(5, "Hello World"));
     });
   });
 
   describe("Ctrl key combinations", () => {
     it("moves cursor to start of previous word when ctrl+ArrowLeft is pressed from middle", () => {
-      const result = calcTextarea(6, "Hello World", ["ctrl", "ArrowLeft"]);
-      expect(result).toEqual({ cursorPos: 0, text: "Hello World" });
+      const result = calcTextarea(aState(6, "Hello World"), [
+        "ctrl",
+        "ArrowLeft",
+      ]);
+      expect(result).toEqual(aState(0, "Hello World"));
     });
 
     it("moves cursor to start of previous word when ctrl+ArrowLeft is pressed from end", () => {
-      const result = calcTextarea(11, "Hello World", ["ctrl", "ArrowLeft"]);
-      expect(result).toEqual({ cursorPos: 6, text: "Hello World" });
+      const result = calcTextarea(aState(11, "Hello World"), [
+        "ctrl",
+        "ArrowLeft",
+      ]);
+      expect(result).toEqual(aState(6, "Hello World"));
     });
 
     it("moves cursor to start of next word when ctrl+ArrowRight is pressed", () => {
-      const result = calcTextarea(0, "Hello World", ["ctrl", "ArrowRight"]);
-      expect(result).toEqual({ cursorPos: 5, text: "Hello World" });
+      const result = calcTextarea(aState(0, "Hello World"), [
+        "ctrl",
+        "ArrowRight",
+      ]);
+      expect(result).toEqual(aState(5, "Hello World"));
     });
 
     it("moves cursor to end of text when ctrl+ArrowRight is pressed and no next word", () => {
-      const result = calcTextarea(6, "Hello World", ["ctrl", "ArrowRight"]);
-      expect(result).toEqual({ cursorPos: 11, text: "Hello World" });
+      const result = calcTextarea(aState(6, "Hello World"), [
+        "ctrl",
+        "ArrowRight",
+      ]);
+      expect(result).toEqual(aState(11, "Hello World"));
     });
 
     it("deletes next word when ctrl+Delete is pressed from start", () => {
-      const result = calcTextarea(0, "Hello World", ["ctrl", "Delete"]);
-      expect(result).toEqual({ cursorPos: 0, text: " World" });
+      const result = calcTextarea(aState(0, "Hello World"), ["ctrl", "Delete"]);
+      expect(result).toEqual(aState(0, " World"));
     });
 
     it("deletes to end of text when ctrl+Delete is pressed and no next word", () => {
-      const result = calcTextarea(6, "Hello World", ["ctrl", "Delete"]);
-      expect(result).toEqual({ cursorPos: 6, text: "Hello " });
+      const result = calcTextarea(aState(6, "Hello World"), ["ctrl", "Delete"]);
+      expect(result).toEqual(aState(6, "Hello "));
     });
 
     it("deletes previous word when ctrl+Backspace is pressed from middle", () => {
-      const result = calcTextarea(6, "Hello World", ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 0, text: "World" });
+      const result = calcTextarea(aState(6, "Hello World"), [
+        "ctrl",
+        "Backspace",
+      ]);
+      expect(result).toEqual(aState(0, "World"));
     });
 
     it("deletes previous word when ctrl+Backspace is pressed from end", () => {
-      const result = calcTextarea(11, "Hello World", ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 6, text: "Hello " });
+      const result = calcTextarea(aState(11, "Hello World"), [
+        "ctrl",
+        "Backspace",
+      ]);
+      expect(result).toEqual(aState(6, "Hello "));
     });
 
     it("does not delete anything when cursor is at start and ctrl+Backspace is pressed", () => {
-      const result = calcTextarea(0, "Hello World", ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 0, text: "Hello World" });
+      const result = calcTextarea(aState(0, "Hello World"), [
+        "ctrl",
+        "Backspace",
+      ]);
+      expect(result).toEqual(aState(0, "Hello World"));
     });
 
-    it("returns original cursor position and text when ctrl+unhandled key is pressed", () => {
-      const result = calcTextarea(5, "Hello World", ["ctrl", "A"]);
-      expect(result).toEqual({ cursorPos: 5, text: "Hello World" });
+    it("returns original state when ctrl+unhandled key is pressed", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["ctrl", "A"]);
+      expect(result).toEqual(aState(5, "Hello World"));
     });
     it("emojis in words", () => {
       const text = "🕷🕷 🐍🐊";
-      const cursorPos = 5;
-      const result = calcTextarea(cursorPos, text, ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 3, text: "🕷🕷 " });
+      const result = calcTextarea(aState(5, text), ["ctrl", "Backspace"]);
+      expect(result).toEqual(aState(3, "🕷🕷 "));
     });
     it("Arrow right with control should move from empty space to the end of the next word", () => {
       const text = "a b c";
-      const cursorPos = 1;
-      const result = calcTextarea(cursorPos, text, ["ctrl", "ArrowRight"]);
-      expect(result).toEqual({ cursorPos: 3, text: "a b c" });
+      const result = calcTextarea(aState(1, text), ["ctrl", "ArrowRight"]);
+      expect(result).toEqual(aState(3, "a b c"));
     });
     it("Backspace with control in the middle of the text should delete the previous word", () => {
       const text = "adf sdlfj ldsjfq sdfsd";
-      const cursorPos = 16;
-      const result = calcTextarea(cursorPos, text, ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 10, text: "adf sdlfj  sdfsd" });
+      const result = calcTextarea(aState(16, text), ["ctrl", "Backspace"]);
+      expect(result).toEqual(aState(10, "adf sdlfj  sdfsd"));
     });
   });
 
   describe("Invalid key combinations", () => {
-    it("returns original cursor position and text when keyCombination length is not 1 or 2", () => {
-      const result = calcTextarea(5, "Hello World", ["Shift", "A"]);
-      expect(result).toEqual({ cursorPos: 5, text: "Hello World" });
+    it("returns original state when modifier is not recognized", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["Shift", "A"]);
+      expect(result).toEqual(aState(5, "Hello World"));
     });
 
-    it("returns original cursor position and text when keyCombination is empty", () => {
-      const result = calcTextarea(5, "Hello World", []);
-      expect(result).toEqual({ cursorPos: 5, text: "Hello World" });
+    it("returns original state when keyCombination is empty", () => {
+      const result = calcTextarea(aState(5, "Hello World"), []);
+      expect(result).toEqual(aState(5, "Hello World"));
     });
   });
+
+  describe("Shift selection", () => {
+    it("starts a selection with shift+ArrowLeft", () => {
+      const result = calcTextarea(aState(5, "Hello World"), [
+        "shift",
+        "ArrowLeft",
+      ]);
+      expect(result).toEqual(aState(4, "Hello World", { selectionAnchor: 5 }));
+    });
+
+    it("extends a selection with shift+ArrowRight", () => {
+      const result = calcTextarea(
+        aState(4, "Hello World", { selectionAnchor: 2 }),
+        ["shift", "ArrowRight"],
+      );
+      expect(result).toEqual(aState(5, "Hello World", { selectionAnchor: 2 }));
+    });
+
+    it("clamps shift+ArrowLeft selection at position 0", () => {
+      const result = calcTextarea(
+        aState(0, "Hello World", { selectionAnchor: 2 }),
+        ["shift", "ArrowLeft"],
+      );
+      expect(result).toEqual(aState(0, "Hello World", { selectionAnchor: 2 }));
+    });
+
+    it("clamps shift+ArrowRight selection at end of text", () => {
+      const result = calcTextarea(
+        aState(11, "Hello World", { selectionAnchor: 6 }),
+        ["shift", "ArrowRight"],
+      );
+      expect(result).toEqual(aState(11, "Hello World", { selectionAnchor: 6 }));
+    });
+
+    it("selects the previous word with ctrl+shift+ArrowLeft", () => {
+      const result = calcTextarea(aState(11, "Hello World"), [
+        "ctrl",
+        "shift",
+        "ArrowLeft",
+      ]);
+      expect(result).toEqual(aState(6, "Hello World", { selectionAnchor: 11 }));
+    });
+
+    it("selects the next word with ctrl+shift+ArrowRight", () => {
+      const result = calcTextarea(aState(0, "Hello World"), [
+        "ctrl",
+        "shift",
+        "ArrowRight",
+      ]);
+      expect(result).toEqual(aState(5, "Hello World", { selectionAnchor: 0 }));
+    });
+
+    it("clears the selection when shift movement returns to the anchor", () => {
+      const result = calcTextarea(
+        aState(4, "Hello World", { selectionAnchor: 5 }),
+        ["shift", "ArrowRight"],
+      );
+      expect(result).toEqual(aState(5, "Hello World"));
+    });
+
+    it("collapses selection to its start with plain ArrowLeft", () => {
+      const result = calcTextarea(
+        aState(8, "Hello World", { selectionAnchor: 3 }),
+        ["ArrowLeft"],
+      );
+      expect(result).toEqual(aState(3, "Hello World"));
+    });
+
+    it("collapses selection to its end with plain ArrowRight", () => {
+      const result = calcTextarea(
+        aState(3, "Hello World", { selectionAnchor: 8 }),
+        ["ArrowRight"],
+      );
+      expect(result).toEqual(aState(8, "Hello World"));
+    });
+
+    it("clears selection and word-moves with ctrl+ArrowLeft", () => {
+      const result = calcTextarea(
+        aState(8, "Hello World", { selectionAnchor: 11 }),
+        ["ctrl", "ArrowLeft"],
+      );
+      expect(result).toEqual(aState(6, "Hello World"));
+    });
+  });
+
+  describe("Deleting with a selection", () => {
+    it("deletes the selected range with Backspace", () => {
+      const result = calcTextarea(
+        aState(8, "Hello World", { selectionAnchor: 3 }),
+        ["Backspace"],
+      );
+      expect(result).toEqual(aState(3, "Helrld"));
+    });
+
+    it("deletes the selected range with Delete", () => {
+      const result = calcTextarea(
+        aState(3, "Hello World", { selectionAnchor: 8 }),
+        ["Delete"],
+      );
+      expect(result).toEqual(aState(3, "Helrld"));
+    });
+
+    it("deletes only the selected range with ctrl+Backspace", () => {
+      const result = calcTextarea(
+        aState(8, "Hello World", { selectionAnchor: 6 }),
+        ["ctrl", "Backspace"],
+      );
+      expect(result).toEqual(aState(6, "Hello rld"));
+    });
+  });
+
+  describe("Clipboard operations", () => {
+    it("cuts the selection to the clipboard with ctrl+x", () => {
+      const result = calcTextarea(
+        aState(11, "Hello World", { selectionAnchor: 5 }),
+        ["ctrl", "x"],
+      );
+      expect(result).toEqual(aState(5, "Hello", { clipboard: " World" }));
+    });
+
+    it("does nothing on ctrl+x without a selection", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["ctrl", "x"]);
+      expect(result).toEqual(aState(5, "Hello World"));
+    });
+
+    it("overwrites the previous clipboard content on ctrl+x", () => {
+      const result = calcTextarea(
+        aState(5, "Hello World", { selectionAnchor: 0, clipboard: "old" }),
+        ["ctrl", "x"],
+      );
+      expect(result).toEqual(aState(0, " World", { clipboard: "Hello" }));
+    });
+
+    it("copies the selection with ctrl+c and keeps the selection", () => {
+      const result = calcTextarea(
+        aState(5, "Hello World", { selectionAnchor: 0 }),
+        ["ctrl", "c"],
+      );
+      expect(result).toEqual(
+        aState(5, "Hello World", { selectionAnchor: 0, clipboard: "Hello" }),
+      );
+    });
+
+    it("does nothing on ctrl+c without a selection", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["ctrl", "c"]);
+      expect(result).toEqual(aState(5, "Hello World"));
+    });
+
+    it("pastes the clipboard at the cursor with ctrl+v", () => {
+      const result = calcTextarea(
+        aState(5, "Hello World", { clipboard: " there" }),
+        ["ctrl", "v"],
+      );
+      expect(result).toEqual(
+        aState(11, "Hello there World", { clipboard: " there" }),
+      );
+    });
+
+    it("replaces the selection with the clipboard on ctrl+v", () => {
+      const result = calcTextarea(
+        aState(11, "Hello World", { selectionAnchor: 6, clipboard: "you" }),
+        ["ctrl", "v"],
+      );
+      expect(result).toEqual(aState(9, "Hello you", { clipboard: "you" }));
+    });
+
+    it("does nothing on ctrl+v with an empty clipboard", () => {
+      const result = calcTextarea(aState(5, "Hello World"), ["ctrl", "v"]);
+      expect(result).toEqual(aState(5, "Hello World"));
+    });
+
+    it("cuts and pastes emoji words losslessly", () => {
+      // "🐶 🐱 🐭" as code points: 🐶=0, space=1, 🐱=2, space=3, 🐭=4
+      let state = aState(5, "🐶 🐱 🐭");
+      state = calcTextarea(state, ["shift", "ArrowLeft"]);
+      state = calcTextarea(state, ["shift", "ArrowLeft"]);
+      state = calcTextarea(state, ["ctrl", "x"]);
+      expect(state).toEqual(aState(3, "🐶 🐱", { clipboard: " 🐭" }));
+      state = calcTextarea(state, ["ctrl", "ArrowLeft"]);
+      state = calcTextarea(state, ["ArrowLeft"]);
+      state = calcTextarea(state, ["ctrl", "v"]);
+      expect(state).toEqual(aState(3, "🐶 🐭 🐱", { clipboard: " 🐭" }));
+    });
+  });
+
   describe("Line Breaks Handling", () => {
     const multiLineText = "Hello\nWorld\nThis is a test";
 
     describe("Single key operations with line breaks", () => {
       it("moves cursor across lines with ArrowLeft", () => {
         // Cursor at the start of 'World'
-        const cursorPos = 6;
-        const result = calcTextarea(cursorPos, multiLineText, ["ArrowLeft"]);
-        expect(result).toEqual({ cursorPos: 5, text: multiLineText });
+        const result = calcTextarea(aState(6, multiLineText), ["ArrowLeft"]);
+        expect(result).toEqual(aState(5, multiLineText));
       });
 
       it("moves cursor across lines with ArrowRight", () => {
         // Cursor at the end of 'Hello'
-        const cursorPos = 5;
-        const result = calcTextarea(cursorPos, multiLineText, ["ArrowRight"]);
-        expect(result).toEqual({ cursorPos: 6, text: multiLineText });
+        const result = calcTextarea(aState(5, multiLineText), ["ArrowRight"]);
+        expect(result).toEqual(aState(6, multiLineText));
       });
 
       it("deletes newline character with Backspace", () => {
         // Cursor at the start of 'World'
-        const cursorPos = 6;
-        const result = calcTextarea(cursorPos, multiLineText, ["Backspace"]);
-        expect(result).toEqual({
-          cursorPos: 5,
-          text: "HelloWorld\nThis is a test",
-        });
+        const result = calcTextarea(aState(6, multiLineText), ["Backspace"]);
+        expect(result).toEqual(aState(5, "HelloWorld\nThis is a test"));
       });
 
       it("deletes newline character with Delete", () => {
         // Cursor at the end of 'Hello'
-        const cursorPos = 5;
-        const result = calcTextarea(cursorPos, multiLineText, ["Delete"]);
-        expect(result).toEqual({
-          cursorPos: 5,
-          text: "HelloWorld\nThis is a test",
-        });
+        const result = calcTextarea(aState(5, multiLineText), ["Delete"]);
+        expect(result).toEqual(aState(5, "HelloWorld\nThis is a test"));
       });
     });
 
     describe("Ctrl key combinations with line breaks", () => {
       it("moves cursor to start of previous word across lines with ctrl+ArrowLeft", () => {
         // Cursor at the start of 'This'
-        const cursorPos = 12;
-        const result = calcTextarea(cursorPos, multiLineText, [
+        const result = calcTextarea(aState(12, multiLineText), [
           "ctrl",
           "ArrowLeft",
         ]);
-        expect(result).toEqual({ cursorPos: 6, text: multiLineText });
+        expect(result).toEqual(aState(6, multiLineText));
       });
 
       it("moves cursor to end of next word across lines with ctrl+ArrowRight", () => {
         // Cursor at the end of 'World'
-        const cursorPos = 11;
-        const result = calcTextarea(cursorPos, "Hello\nWorld\nThis is a test", [
+        const result = calcTextarea(aState(11, multiLineText), [
           "ctrl",
           "ArrowRight",
         ]);
-        expect(result).toEqual({ cursorPos: 16, text: multiLineText });
+        expect(result).toEqual(aState(16, multiLineText));
       });
       it("deletes next word across lines with ctrl+Delete", () => {
         // Cursor at the end of 'Hello'
-        const cursorPos = 5;
-        const result = calcTextarea(cursorPos, multiLineText, [
+        const result = calcTextarea(aState(5, multiLineText), [
           "ctrl",
           "Delete",
         ]);
-        expect(result).toEqual({
-          cursorPos: 5,
-          text: "Hello\nThis is a test",
-        });
+        expect(result).toEqual(aState(5, "Hello\nThis is a test"));
       });
 
       it("deletes previous word across lines with ctrl+Backspace", () => {
         // Cursor at the start of 'This'
-        const cursorPos = 12;
-        const result = calcTextarea(cursorPos, multiLineText, [
+        const result = calcTextarea(aState(12, multiLineText), [
           "ctrl",
           "Backspace",
         ]);
-        expect(result).toEqual({
-          cursorPos: 6,
-          text: "Hello\nThis is a test",
-        });
+        expect(result).toEqual(aState(6, "Hello\nThis is a test"));
       });
     });
 
     describe("Edge cases with line breaks", () => {
       it("does not move cursor left when at position 0 in multi-line text", () => {
-        const result = calcTextarea(0, multiLineText, ["ArrowLeft"]);
-        expect(result).toEqual({ cursorPos: 0, text: multiLineText });
+        const result = calcTextarea(aState(0, multiLineText), ["ArrowLeft"]);
+        expect(result).toEqual(aState(0, multiLineText));
       });
 
       it("does not move cursor right when at end of multi-line text", () => {
-        const result = calcTextarea(multiLineText.length, multiLineText, [
+        const result = calcTextarea(aState(multiLineText.length, multiLineText), [
           "ArrowRight",
         ]);
-        expect(result).toEqual({
-          cursorPos: multiLineText.length,
-          text: multiLineText,
-        });
+        expect(result).toEqual(aState(multiLineText.length, multiLineText));
       });
 
       it("deletes character before cursor at start of line with Backspace", () => {
         // Cursor at the start of 'World' on second line
-        const cursorPos = 6;
-        const result = calcTextarea(cursorPos, multiLineText, ["Backspace"]);
-        expect(result).toEqual({
-          cursorPos: 5,
-          text: "HelloWorld\nThis is a test",
-        });
+        const result = calcTextarea(aState(6, multiLineText), ["Backspace"]);
+        expect(result).toEqual(aState(5, "HelloWorld\nThis is a test"));
       });
 
       it("deletes character at cursor at end of line with Delete", () => {
         // Cursor at the end of 'Hello'
-        const cursorPos = 5;
-        const result = calcTextarea(cursorPos, multiLineText, ["Delete"]);
-        expect(result).toEqual({
-          cursorPos: 5,
-          text: "HelloWorld\nThis is a test",
-        });
+        const result = calcTextarea(aState(5, multiLineText), ["Delete"]);
+        expect(result).toEqual(aState(5, "HelloWorld\nThis is a test"));
       });
     });
   });
@@ -259,15 +439,21 @@ describe("calcTextarea", () => {
     it("moves cursor to start of word when ctrl+ArrowLeft is pressed at middle of text with newline", () => {
       const text = "a\nb c";
       const cursorPos = 3; // After 'b'
-      const result = calcTextarea(cursorPos, text, ["ctrl", "ArrowLeft"]);
-      expect(result).toEqual({ cursorPos: 2, text });
+      const result = calcTextarea(aState(cursorPos, text), [
+        "ctrl",
+        "ArrowLeft",
+      ]);
+      expect(result).toEqual(aState(2, text));
     });
 
     it("deletes previous word when ctrl+Backspace is pressed at middle of text with newline", () => {
       const text = "a\nb c";
       const cursorPos = 3; // After 'b'
-      const result = calcTextarea(cursorPos, text, ["ctrl", "Backspace"]);
-      expect(result).toEqual({ cursorPos: 2, text: "a\n c" });
+      const result = calcTextarea(aState(cursorPos, text), [
+        "ctrl",
+        "Backspace",
+      ]);
+      expect(result).toEqual(aState(2, "a\n c"));
     });
   });
 });

--- a/src/app/virtualTextarea/index.ts
+++ b/src/app/virtualTextarea/index.ts
@@ -1,132 +1,183 @@
-export function calcTextarea(
-  cursorPos: number,
-  text: string,
-  keyCombination: string[],
-): { cursorPos: number; text: string } {
-  // Convert text to an array of characters
-  function isWordCharacter(char: string): boolean {
-    return !/\s/.test(char);
+export type ITextareaState = {
+  text: string;
+  cursorPos: number;
+  /**
+   * Selection spans [min(selectionAnchor, cursorPos), max(selectionAnchor, cursorPos)).
+   * null means no selection.
+   */
+  selectionAnchor: number | null;
+  clipboard: string;
+};
+
+function isWordCharacter(char: string): boolean {
+  return !/\s/.test(char);
+}
+
+function wordBoundaryLeft(characters: string[], pos: number): number {
+  // Skip any non-word characters before the position
+  while (pos > 0 && !isWordCharacter(characters[pos - 1])) {
+    pos--;
   }
 
-  const characters = Array.from(text);
+  // Skip word characters to the start of the word
+  while (pos > 0 && isWordCharacter(characters[pos - 1])) {
+    pos--;
+  }
+
+  return pos;
+}
+
+function wordBoundaryRight(characters: string[], pos: number): number {
   const len = characters.length;
 
-  if (keyCombination.length === 1) {
-    switch (keyCombination[0]) {
-      case "ArrowLeft":
-        return {
-          cursorPos: Math.max(0, cursorPos - 1),
-          text: text,
-        };
-      case "ArrowRight":
-        return {
-          cursorPos: Math.min(len, cursorPos + 1),
-          text: text,
-        };
-      case "Backspace":
-        if (cursorPos > 0) {
-          const newCharacters = [...characters];
-          newCharacters.splice(cursorPos - 1, 1);
-          return {
-            cursorPos: cursorPos - 1,
-            text: newCharacters.join(""),
-          };
-        }
-        break;
-      case "Delete":
-        if (cursorPos < len) {
-          const newCharacters = [...characters];
-          newCharacters.splice(cursorPos, 1);
-          return {
-            cursorPos,
-            text: newCharacters.join(""),
-          };
-        }
-        break;
-      default:
-        break;
-    }
+  // Skip non-word characters (including line breaks)
+  while (pos < len && !isWordCharacter(characters[pos])) {
+    pos++;
   }
 
-  if (keyCombination.length === 2 && keyCombination[0] === "ctrl") {
-    switch (keyCombination[1]) {
-      case "ArrowLeft": {
-        let pos = cursorPos;
-
-        // Skip any non-word characters before the cursor
-        while (pos > 0 && !isWordCharacter(characters[pos - 1])) {
-          pos--;
-        }
-
-        // Skip word characters to the start of the word
-        while (pos > 0 && isWordCharacter(characters[pos - 1])) {
-          pos--;
-        }
-
-        return { cursorPos: pos, text: text };
-      }
-      case "ArrowRight": {
-        let pos = cursorPos;
-        const len = characters.length;
-
-        // Skip non-word characters (including line breaks)
-        while (pos < len && !isWordCharacter(characters[pos])) {
-          pos++;
-        }
-
-        // Skip word characters to the end of the next word
-        while (pos < len && isWordCharacter(characters[pos])) {
-          pos++;
-        }
-
-        return { cursorPos: pos, text: text };
-      }
-      case "Backspace": {
-        let pos = cursorPos;
-
-        // Skip any non-word characters before the cursor
-        while (pos > 0 && !isWordCharacter(characters[pos - 1])) {
-          pos--;
-        }
-
-        // Skip word characters to the start of the word
-        while (pos > 0 && isWordCharacter(characters[pos - 1])) {
-          pos--;
-        }
-
-        const newCharacters = [...characters];
-        newCharacters.splice(pos, cursorPos - pos);
-
-        return {
-          cursorPos: pos,
-          text: newCharacters.join(""),
-        };
-      }
-      case "Delete": {
-        let pos = cursorPos;
-
-        // Skip any non-word characters at or after the cursor
-        while (pos < len && !isWordCharacter(characters[pos])) {
-          pos++;
-        }
-
-        // Skip word characters to the end of the word
-        while (pos < len && isWordCharacter(characters[pos])) {
-          pos++;
-        }
-
-        const newCharacters = [...characters];
-        newCharacters.splice(cursorPos, pos - cursorPos);
-
-        return {
-          cursorPos: cursorPos,
-          text: newCharacters.join(""),
-        };
-      }
-      default:
-        break;
-    }
+  // Skip word characters to the end of the next word
+  while (pos < len && isWordCharacter(characters[pos])) {
+    pos++;
   }
 
-  return { cursorPos, text: text };
+  return pos;
+}
+
+export function calcTextarea(
+  state: ITextareaState,
+  keyCombination: string[],
+): ITextareaState {
+  if (keyCombination.length === 0) {
+    return state;
+  }
+  const baseKey = keyCombination[keyCombination.length - 1];
+  const modifiers = keyCombination.slice(0, -1);
+  if (
+    modifiers.some((modifier) => modifier !== "ctrl" && modifier !== "shift")
+  ) {
+    return state;
+  }
+  const ctrl = modifiers.includes("ctrl");
+  const shift = modifiers.includes("shift");
+
+  // Convert text to an array of characters (code points, emoji-safe)
+  const characters = Array.from(state.text);
+  const len = characters.length;
+
+  const selectionStart =
+    state.selectionAnchor === null
+      ? state.cursorPos
+      : Math.min(state.selectionAnchor, state.cursorPos);
+  const selectionEnd =
+    state.selectionAnchor === null
+      ? state.cursorPos
+      : Math.max(state.selectionAnchor, state.cursorPos);
+  const hasSelection = selectionStart < selectionEnd;
+
+  function deleteSelection(): ITextareaState {
+    const newCharacters = [...characters];
+    newCharacters.splice(selectionStart, selectionEnd - selectionStart);
+    return {
+      ...state,
+      text: newCharacters.join(""),
+      cursorPos: selectionStart,
+      selectionAnchor: null,
+    };
+  }
+
+  if (baseKey === "ArrowLeft" || baseKey === "ArrowRight") {
+    if (shift) {
+      const anchor = state.selectionAnchor ?? state.cursorPos;
+      const newCursorPos =
+        baseKey === "ArrowLeft"
+          ? ctrl
+            ? wordBoundaryLeft(characters, state.cursorPos)
+            : Math.max(0, state.cursorPos - 1)
+          : ctrl
+            ? wordBoundaryRight(characters, state.cursorPos)
+            : Math.min(len, state.cursorPos + 1);
+      return {
+        ...state,
+        cursorPos: newCursorPos,
+        selectionAnchor: newCursorPos === anchor ? null : anchor,
+      };
+    }
+    if (hasSelection && !ctrl) {
+      // Plain arrows collapse the selection to its edge
+      return {
+        ...state,
+        cursorPos: baseKey === "ArrowLeft" ? selectionStart : selectionEnd,
+        selectionAnchor: null,
+      };
+    }
+    const newCursorPos =
+      baseKey === "ArrowLeft"
+        ? ctrl
+          ? wordBoundaryLeft(characters, state.cursorPos)
+          : Math.max(0, state.cursorPos - 1)
+        : ctrl
+          ? wordBoundaryRight(characters, state.cursorPos)
+          : Math.min(len, state.cursorPos + 1);
+    return { ...state, cursorPos: newCursorPos, selectionAnchor: null };
+  }
+
+  if ((baseKey === "Backspace" || baseKey === "Delete") && !shift) {
+    if (hasSelection) {
+      return deleteSelection();
+    }
+    if (baseKey === "Backspace") {
+      const deleteFrom = ctrl
+        ? wordBoundaryLeft(characters, state.cursorPos)
+        : Math.max(0, state.cursorPos - 1);
+      const newCharacters = [...characters];
+      newCharacters.splice(deleteFrom, state.cursorPos - deleteFrom);
+      return {
+        ...state,
+        text: newCharacters.join(""),
+        cursorPos: deleteFrom,
+        selectionAnchor: null,
+      };
+    }
+    const deleteTo = ctrl
+      ? wordBoundaryRight(characters, state.cursorPos)
+      : Math.min(len, state.cursorPos + 1);
+    const newCharacters = [...characters];
+    newCharacters.splice(state.cursorPos, deleteTo - state.cursorPos);
+    return {
+      ...state,
+      text: newCharacters.join(""),
+      selectionAnchor: null,
+    };
+  }
+
+  if (ctrl && !shift && (baseKey === "x" || baseKey === "c" || baseKey === "v")) {
+    if (baseKey === "v") {
+      if (state.clipboard === "") {
+        return state;
+      }
+      const clipboardCharacters = Array.from(state.clipboard);
+      const newCharacters = [...characters];
+      newCharacters.splice(
+        selectionStart,
+        selectionEnd - selectionStart,
+        ...clipboardCharacters,
+      );
+      return {
+        ...state,
+        text: newCharacters.join(""),
+        cursorPos: selectionStart + clipboardCharacters.length,
+        selectionAnchor: null,
+      };
+    }
+    if (!hasSelection) {
+      return state;
+    }
+    const selectedText = characters.slice(selectionStart, selectionEnd).join("");
+    if (baseKey === "c") {
+      return { ...state, clipboard: selectedText };
+    }
+    return { ...deleteSelection(), clipboard: selectedText };
+  }
+
+  return state;
 }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { levels } from "../app/levels";
 
 export const usernameSchema = z
   .string()
@@ -9,7 +10,7 @@ export const usernameSchema = z
     "Must consist of letters, digits and spaces. At least one letter. Consecutive spaces are not allowed.",
   );
 
-const LAST_LEVEL = 5;
+const LAST_LEVEL = levels.length;
 const MAX_KEYS_IN_LEVEL = 3000;
 const gameHistorySchema = z
   .array(


### PR DESCRIPTION
Replace calcTextarea's positional signature with an ITextareaState object
carrying text, cursor, selection anchor and clipboard. Support
shift/ctrl+shift arrow selection, selection-aware deletes and
ctrl+x/c/v cut/copy/paste. Migrate the level engine and game validation
to the new state-based API and extend the unit tests.

https://claude.ai/code/session_019pAePn3q99cNrTcFLrw7ZA